### PR TITLE
fix(target): drop invalid encoding arg from binary image read

### DIFF
--- a/backend/agents/target/tool.py
+++ b/backend/agents/target/tool.py
@@ -85,7 +85,7 @@ async def select_random_target_image() -> str:
     image_path = targets_dir / selected_file
 
     # Read the image file and compress it
-    with open(image_path, "rb", encoding="utf-8") as image_file:
+    with open(image_path, "rb") as image_file:
         image_data = image_file.read()
         # Compress the image to reduce token count
         compressed_base64 = compress_image(


### PR DESCRIPTION
`select_random_target_image()` opened the target image with `open(image_path, "rb", encoding="utf-8")`. Python rejects an `encoding` argument in binary mode, raising `binary mode doesn't take an encoding argument` on **every** session creation (`create_session` WebSocket event). Removing the invalid argument restores session creation.