### PR TITLE
fix(config): update retired gemini model defaults

### DIFF
--- a/backend/core/config/settings.py
+++ b/backend/core/config/settings.py
@@ -5,8 +5,8 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = "https://localhost:3000"
     DATABASE_URL: str = "sqlite+aiosqlite:///database.db"
 
-    LLM_MODEL: str = "gemini-2.5-flash"
-    IMAGE_MODEL: str = "gemini-2.5-flash-image"
+    LLM_MODEL: str = "gemini-3.6-flash"
+    IMAGE_MODEL: str = "gemini-3.1-flash-image"
     GOOGLE_API_KEY: str
 
     model_config = SettingsConfigDict(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the default Gemini model names in `backend/core/config/settings.py`, which point at models Google has retired for new users. This breaks the app's core AI features (monitor chat, target-model image generation, session scoring).

## Detail

`gemini-2.5-flash` now returns `404 NOT_FOUND` for new API keys:

```
This model models/gemini-2.5-flash is no longer available to new users.
Please update your code to use models/gemini-3.6-flash for the latest features and improvements.
```

Changes:

| Setting | Before | After |
| --- | --- | --- |
| `LLM_MODEL` | `gemini-2.5-flash` | `gemini-3.6-flash` |
| `IMAGE_MODEL` | `gemini-2.5-flash-image` | `gemini-3.1-flash-image` |

`gemini-3.6-flash` is Google's own suggested replacement, confirmed valid against the live `ListModels` API (retired models return `404`; the new names resolve and reach the account/quota check). `gemini-3.1-flash-image` is the current stable flash image-generation model.

## Verification

Verified in a fresh Cloud Agent with a real `GOOGLE_API_KEY`: the backend authenticates and calls Google successfully; the retired `gemini-2.5-flash` failed model resolution with `404`, while `gemini-3.6-flash` resolves and reaches Google's quota check. These values are overridable via env (`LLM_MODEL` / `IMAGE_MODEL`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dbca3ec-e3be-4885-9d1c-8fbf7849102c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dbca3ec-e3be-4885-9d1c-8fbf7849102c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

